### PR TITLE
changes unicode_utils version to 1.2.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     sort_alphabetical (1.0.0)
-      unicode_utils (>= 1.0.0)
+      unicode_utils (>= 1.2.2)
 
 GEM
   remote: https://rubygems.org/

--- a/sort_alphabetical.gemspec
+++ b/sort_alphabetical.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new name, '1.0.0' do |s|
   s.homepage = "https://github.com/grosser/#{name}"
   s.files = `git ls-files lib`.split("\n")
   s.license = "MIT"
-  s.add_dependency 'unicode_utils', '>= 1.0.0'
+  s.add_dependency 'unicode_utils', '>= 1.2.2'
   key = File.expand_path("~/.ssh/gem-private_key.pem")
   if File.exist?(key)
     s.signing_key = key


### PR DESCRIPTION
Previous versions of unicode_utils does not have [general_category.rb](https://github.com/lang/unicode_utils/blob/v1.2.2/lib/unicode_utils/general_category.rb) which is included in [sort_alphabetical.rb](https://github.com/grosser/sort_alphabetical/blob/master/lib/sort_alphabetical.rb#L4)
