### PR TITLE
Freeze un-mutated string literal

### DIFF
--- a/lib/sort_alphabetical.rb
+++ b/lib/sort_alphabetical.rb
@@ -19,7 +19,7 @@ module SortAlphabetical
   end
 
   def normalize(string)
-    UnicodeUtils.compatibility_decomposition(string).split('').select do |c|
+    UnicodeUtils.compatibility_decomposition(string).split(''.freeze).select do |c|
       UnicodeUtils.general_category(c) =~ /Letter|Separator|Punctuation|Number/
     end.join
   end


### PR DESCRIPTION
Why: Saves 2253 strings from allocated on every request

```
2253) /Users/Juan/.gem/ruby/2.2.2/gems/sort_alphabetical-1.0.1/lib/sort_alphabetical.rb
  - 2253) String#split on line 22
```

Reproduce steps:

```
git clone https://github.com/JuanitoFatas/iso3166_exp
cd iso3166_exp
bin/setup
bin/rake db:migrate
bin/rails s
visit http://localhost:3000
see logs from rails s:

Started GET "/" for 127.0.0.1 at 2015-08-14 18:45:15 +0800
Processing by HomeController#index as HTML
## Un-Fozen Hotspots (2516 total)

  2253) /Users/Juan/.gem/ruby/2.2.2/gems/sort_alphabetical-1.0.1/lib/sort_alphabetical.rb
    - 2253) String#split on line 22
  253) /Users/Juan/.gem/ruby/2.2.2/gems/actionview-4.2.3/lib/action_view/helpers/tags/base.rb
    - 48) String#sub! on line 14
    - 46) String#sub on line 114
    - 46) String#gsub on line 114
    - 44) String#sub! on line 14
    - 24) Array#join on line 94
    - 23) String#sub on line 118
    - 22) Array#join on line 94
  4) /Users/Juan/.gem/ruby/2.2.2/gems/activesupport-4.2.3/lib/active_support/inflector/methods.rb
    - 2) String#tr! on line 132
    - 1) String#sub! on line 131
    - 1) String#sub! on line 130
  3) /Users/Juan/.gem/ruby/2.2.2/gems/actionpack-4.2.3/lib/action_dispatch/http/url.rb
    - 1) String#<< on line 113
    - 1) String#chomp on line 52
    - 1) String#sub on line 196
  1) /Users/Juan/.gem/ruby/2.2.2/gems/actionview-4.2.3/lib/action_view/helpers/tags/translator.rb
    - 1) String#gsub on line 6
  1) /Users/Juan/.gem/ruby/2.2.2/gems/activemodel-4.2.3/lib/active_model/translation.rb
    - 1) String#split on line 45
  1) /Users/Juan/.rubies/ruby-2.2.2/lib/ruby/2.2.0/base64.rb
    - 1) String#unpack on line 73
```

-- 

This finding tool is called [let_it_go](https://github.com/schneems/let_it_go). I use it to find this in the [view](https://github.com/JuanitoFatas/iso3166_exp/blob/master/app/views/home/index.html.erb#L1).